### PR TITLE
Fixed use of view-page instead of view for config

### DIFF
--- a/src/MisterPhilip/MaintenanceMode/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/MisterPhilip/MaintenanceMode/Http/Middleware/CheckForMaintenanceMode.php
@@ -126,7 +126,7 @@ class CheckForMaintenanceMode implements Middleware
                 $this->app['session']->start();
 
                 // The user isn't exempt, let's show them the maintenance page!
-                $view = $this->app['config']->get('maintenancemode.view-page', 'maintenancemode::app-down');
+                $view = $this->app['config']->get('maintenancemode.view', 'maintenancemode::app-down');
 
                 // $view = 'errors.503';
                 return new Response(view($view, $info), 503);


### PR DESCRIPTION
It was using 'view-page' as the key to get from the config rather than view, easier to change this than every instance of view to view-page I'd say.
