### PR TITLE
Use base_path() instead of self::BASE_PATH

### DIFF
--- a/src/MisterPhilip/MaintenanceMode/MaintenanceModeServiceProvider.php
+++ b/src/MisterPhilip/MaintenanceMode/MaintenanceModeServiceProvider.php
@@ -46,7 +46,7 @@ class MaintenanceModeServiceProvider extends ServiceProvider
      */
     protected function loadViews()
     {
-        $this->loadViewsFrom(base_path() . '/views', 'maintenancemode');
+        $this->loadViewsFrom(BASE_PATH . 'views', 'maintenancemode');
 
         $this->publishes([
             BASE_PATH . 'views' => base_path('resources/views/vendor/maintenancemode'),

--- a/src/MisterPhilip/MaintenanceMode/MaintenanceModeServiceProvider.php
+++ b/src/MisterPhilip/MaintenanceMode/MaintenanceModeServiceProvider.php
@@ -1,5 +1,7 @@
 <?php namespace MisterPhilip\MaintenanceMode;
 
+define('BASE_PATH', __DIR__ . "/../../");
+
 use Illuminate\Support\ServiceProvider;
 
 class MaintenanceModeServiceProvider extends ServiceProvider
@@ -33,7 +35,7 @@ class MaintenanceModeServiceProvider extends ServiceProvider
 	public function register()
 	{
         $this->mergeConfigFrom(
-            base_path() . '/config/maintenancemode.php', 'maintenancemode'
+            BASE_PATH . 'config/maintenancemode.php', 'maintenancemode'
         );
 	}
 
@@ -47,7 +49,7 @@ class MaintenanceModeServiceProvider extends ServiceProvider
         $this->loadViewsFrom(base_path() . '/views', 'maintenancemode');
 
         $this->publishes([
-            base_path() . '/views' => base_path('resources/views/vendor/maintenancemode'),
+            BASE_PATH . 'views' => base_path('resources/views/vendor/maintenancemode'),
         ], 'views');
     }
 
@@ -58,7 +60,7 @@ class MaintenanceModeServiceProvider extends ServiceProvider
      */
     protected function loadTranslations()
     {
-        $this->loadTranslationsFrom(base_path() . '/lang', 'maintenancemode');
+        $this->loadTranslationsFrom(BASE_PATH . 'lang', 'maintenancemode');
     }
 
     /**
@@ -69,7 +71,7 @@ class MaintenanceModeServiceProvider extends ServiceProvider
     protected function loadConfig()
     {
         $this->publishes([
-            base_path() . '/config/maintenancemode.php' => config_path('maintenancemode.php'),
+             BASE_PATH . 'config/maintenancemode.php' => config_path('maintenancemode.php'),
         ], 'config');
     }
 }

--- a/src/MisterPhilip/MaintenanceMode/MaintenanceModeServiceProvider.php
+++ b/src/MisterPhilip/MaintenanceMode/MaintenanceModeServiceProvider.php
@@ -12,8 +12,6 @@ class MaintenanceModeServiceProvider extends ServiceProvider
 	 */
 	protected $defer = false;
 
-    const BASE_PATH = __DIR__ . '/../../';
-
     /**
      * Bootstrap our application events.
      *
@@ -35,7 +33,7 @@ class MaintenanceModeServiceProvider extends ServiceProvider
 	public function register()
 	{
         $this->mergeConfigFrom(
-            self::BASE_PATH . 'config/maintenancemode.php', 'maintenancemode'
+            base_path() . '/config/maintenancemode.php', 'maintenancemode'
         );
 	}
 
@@ -46,10 +44,10 @@ class MaintenanceModeServiceProvider extends ServiceProvider
      */
     protected function loadViews()
     {
-        $this->loadViewsFrom(self::BASE_PATH . 'views', 'maintenancemode');
+        $this->loadViewsFrom(base_path() . '/views', 'maintenancemode');
 
         $this->publishes([
-            self::BASE_PATH . 'views' => base_path('resources/views/vendor/maintenancemode'),
+            base_path() . '/views' => base_path('resources/views/vendor/maintenancemode'),
         ], 'views');
     }
 
@@ -60,7 +58,7 @@ class MaintenanceModeServiceProvider extends ServiceProvider
      */
     protected function loadTranslations()
     {
-        $this->loadTranslationsFrom(self::BASE_PATH . 'lang', 'maintenancemode');
+        $this->loadTranslationsFrom(base_path() . '/lang', 'maintenancemode');
     }
 
     /**
@@ -71,7 +69,7 @@ class MaintenanceModeServiceProvider extends ServiceProvider
     protected function loadConfig()
     {
         $this->publishes([
-            self::BASE_PATH . 'config/maintenancemode.php' => config_path('maintenancemode.php'),
+            base_path() . '/config/maintenancemode.php' => config_path('maintenancemode.php'),
         ], 'config');
     }
 }


### PR DESCRIPTION
`protected $BASE_PATH = __DIR__ . '/../../'` only works in PHP 5.6+, Laravel 5.1 has a requirement of 5.5.9+ so it seems a bit silly to require 5.6 just for one little line when base_path() already exists.
