### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.3",
+        "illuminate/support": "5.3.*",
         "nesbot/carbon": "~1.19"
     },
     "autoload": {


### PR DESCRIPTION
`composer require`-ing the development branch removes the latest version of the Laravel framework and instead attempts to install 5.3.0.