### PR TITLE
Development for Laravel 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enhanced Laravel 5 Maintenance Mode
 
-This package is a drop-in replacement for Laravel 5.3's maintenance mode. For 5.0 - 5.2, please use the 
+This package is a drop-in replacement for Laravel 5.6's maintenance mode. For 5.0 - 5.2, please use the 
 [1.0 branch](https://github.com/MisterPhilip/maintenance-mode/tree/1.0)! Features include:
  - Allowing custom maintenance messages to be shown to users
  - Including a timestamp of when the application went down
@@ -76,7 +76,7 @@ with
 
 ## Changes from 1.0
 
-With Laravel 5.3, messages are now allowed in the default `artisan down` command, as well as adding an option for the 
+With Laravel 5.6, messages are now allowed in the default `artisan down` command, as well as adding an option for the 
 `Retry-After` HTTP header. Because of this it should be noted that the syntax to call the `artisan down` command has 
 changed from the 1.0 branch to better match Laravel's default command.
 

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.3 - 5.4",
-        "nesbot/carbon": "~1.20"
+        "illuminate/support": "5.6.*",
+        "nesbot/carbon": "^1.24"
     },
     "autoload": {
         "psr-0": {

--- a/src/MisterPhilip/MaintenanceMode/Console/Commands/StartMaintenanceCommand.php
+++ b/src/MisterPhilip/MaintenanceMode/Console/Commands/StartMaintenanceCommand.php
@@ -32,7 +32,7 @@ class StartMaintenanceCommand extends DownCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $payload = $this->getDownFilePayload();
         if($this->abort)

--- a/src/MisterPhilip/MaintenanceMode/Exceptions/MaintenanceModeException.php
+++ b/src/MisterPhilip/MaintenanceMode/Exceptions/MaintenanceModeException.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace MisterPhilip\MaintenanceMode\Exceptions;
+
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\Response;
+
+class MaintenanceModeException extends \Illuminate\Foundation\Http\Exceptions\MaintenanceModeException implements Responsable
+{
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\Http\Response|\Illuminate\View\View
+     */
+    public function toResponse($request)
+    {
+        $viewName = config('maintenancemode.view');
+        $downFile = storage_path('framework/down');
+        if (file_exists($downFile)) {
+            $downData = json_decode(file_get_contents($downFile));
+
+            if ($downData->view != null) {
+                $viewName = $downData->view;
+            }
+        }
+
+        return new Response(view($viewName));
+    }
+}

--- a/src/lang/nl/defaults.php
+++ b/src/lang/nl/defaults.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+    /**
+     * Title of the maintenance page
+     *
+     * @var string
+     */
+    'title' => 'Onderhoudsmodus',
+
+    /**
+     * Default application down message, shown on the maintenance page
+     *
+     * @var string
+     */
+    'message' => 'Op dit moment wordt aan de website gewerkt, probeer het a.u.b. straks nog eens',
+
+    /**
+     * Last updated string, shown on the maintenance page
+     *
+     * @var string
+     */
+    'last-updated' => 'Laatste update was :timestamp',
+
+    /**
+     * Exception messages
+     *
+     * @var array
+     */
+    'exceptions' => [
+        'invalid' => 'Klasse :class extend \MisterPhilip\MaintenanceMode\Exemptions\MaintenanceModeExemption niet',
+        'missing' => 'Klasse :class bestaat niet',
+    ]
+];

--- a/src/views/notification.blade.php
+++ b/src/views/notification.blade.php
@@ -15,6 +15,7 @@
                 padding: .5em;
                 background-color: #FF130F;
                 color: #fff;
+                font-family: sans-serif;
             }
             .maintenance-mode-alert strong {
                 font-weight: bold;
@@ -30,7 +31,7 @@
 
     <div class="maintenance-mode-alert" id="maintenance-mode-alert" role="alert">
 
-        <strong>Maintenance Mode</strong>
+        <strong>@lang('maintenancemode::defaults.title'):</strong>
 
         {{-- Show the truncated message (so it doesn't overflow) --}}
         @if(isset(${Config::get('maintenancemode.inject.prefix').'Message'}))


### PR DESCRIPTION
I have updated the repository to become compatible with Laravel 5.6, and tweaked the notification template a bit. Changes I made:

- Updated the Composer dependencies to Laravel 5.6.* and Carbon ^1.24
- Updated the command handling for `StartMaintenanceCommand.php`
- Added `MaintenanceModeException`
- Added additional checks in `CheckForMaintenanceMode.php`
- Added Dutch translations (because I want to use this in my Dutch projects 😄)
- Improved the readability of the maintenance mode notification bar
- Updated `README.md`