### PR TITLE
- fix error 'The "allow" option does not exist.'

### DIFF
--- a/src/MisterPhilip/MaintenanceMode/Console/Commands/StartMaintenanceCommand.php
+++ b/src/MisterPhilip/MaintenanceMode/Console/Commands/StartMaintenanceCommand.php
@@ -27,7 +27,8 @@ class StartMaintenanceCommand extends DownCommand
      */
     protected $signature = 'down {--message= : The message for the maintenance mode. }
             {--retry= : The number of seconds after which the request may be retried.}
-            {--view= : The view to use for this instance of maintenance mode.}';
+	    {--view= : The view to use for this instance of maintenance mode.}
+	    {--allow=* : IP or networks allowed to access the application while in maintenance mode.}';
 
     /**
      * Execute the maintenance mode command

--- a/src/MisterPhilip/MaintenanceMode/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/MisterPhilip/MaintenanceMode/Http/Middleware/CheckForMaintenanceMode.php
@@ -5,6 +5,7 @@ namespace MisterPhilip\MaintenanceMode\Http\Middleware;
 use Carbon\Carbon;
 use Closure;
 use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\IpUtils;
 
 use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode as LaravelMaintenanceMode;
 
@@ -77,6 +78,10 @@ class CheckForMaintenanceMode extends LaravelMaintenanceMode
             $info['Enabled'] = true;
 
             $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
+
+            if (isset($data['allowed']) && IpUtils::checkIp($request->ip(), (array) $data['allowed'])) {
+                return $next($request);
+            }
 
             // Update the array with data from down file
             $info['Timestamp'] = Carbon::createFromTimestamp($data['time']);


### PR DESCRIPTION
When enabling Maintenance mode with 'php artisan down' the following error is displayed:

The "allow" option does not exist.